### PR TITLE
Fix Ruby syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Log Rails application actions and filters when accepts a request.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'action_tracer', group :development, :test
+gem 'action_tracer', group: [:development, :test]
 ```
 
 Notice this gem is for Rails with ApplicationController inherited ActiveController::Base.  


### PR DESCRIPTION
The former code raises an error like the following:
```
[!] There was an error parsing `Gemfile`: syntax error, unexpected symbol literal, expecting `do' or '{' or '(' - gem 'action_tracer', group :development, :test
                           ^
. Bundler cannot continue.

 #  from /app/Gemfile:8
 #  -------------------------------------------
 #
 >  gem 'action_tracer', group :development, :test
 #  -------------------------------------------
```